### PR TITLE
Initial API implementation

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cloud-lada/backend/internal/statistics"
+	"github.com/cloud-lada/backend/pkg/postgres"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+var version = "dev"
+
+func main() {
+	var (
+		databaseURL string
+		port        int
+	)
+
+	cmd := &cobra.Command{
+		Use:     "api",
+		Short:   "Serves statistical data from the database via HTTP",
+		Version: version,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			db, err := postgres.Open(ctx, databaseURL)
+			if err != nil {
+				return fmt.Errorf("failed to connect to database: %w", err)
+			}
+
+			logger := log.Default()
+			router := mux.NewRouter()
+
+			api := statistics.NewHTTP(statistics.NewPostgresRepository(db))
+			api.Register(router)
+
+			svr := &http.Server{
+				Addr:    fmt.Sprint(":", port),
+				Handler: router,
+			}
+
+			grp, ctx := errgroup.WithContext(ctx)
+			grp.Go(func() error {
+				return svr.ListenAndServe()
+			})
+			grp.Go(func() error {
+				<-ctx.Done()
+				return svr.Shutdown(context.Background())
+			})
+
+			logger.Println("Server started on port", port)
+			return grp.Wait()
+		},
+	}
+
+	flags := cmd.PersistentFlags()
+	flags.IntVar(&port, "port", 5000, "The port to listen for HTTP requests from")
+	flags.StringVar(&databaseURL, "database-url", "", "The URL of the database to read data from")
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill, syscall.SIGTERM)
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		cancel()
+		os.Exit(1)
+	}
+}

--- a/internal/statistics/http.go
+++ b/internal/statistics/http.go
@@ -1,0 +1,48 @@
+package statistics
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type (
+	// The HTTP type contains HTTP request handlers that serve statistical data.
+	HTTP struct {
+		statistics Repository
+	}
+
+	// The Repository interface describes types that can query statistical database from persistent
+	// storage.
+	Repository interface {
+		Latest(ctx context.Context) (Statistics, error)
+	}
+)
+
+// NewHTTP returns a new instance of the HTTP type that will serve statistical data queried from the
+// Repository implementation.
+func NewHTTP(statistics Repository) *HTTP {
+	return &HTTP{statistics: statistics}
+}
+
+// Latest handles an inbound HTTP GET request that returns the latest statistics stored within the Repository.
+func (h *HTTP) Latest(w http.ResponseWriter, r *http.Request) {
+	stats, err := h.statistics.Latest(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err = json.NewEncoder(w).Encode(stats); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// Register the HTTP routes into the given router.
+func (h *HTTP) Register(router *mux.Router) {
+	router.HandleFunc("/api/statistics/latest", h.Latest).Methods(http.MethodGet)
+}

--- a/internal/statistics/http_test.go
+++ b/internal/statistics/http_test.go
@@ -1,0 +1,66 @@
+package statistics_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloud-lada/backend/internal/statistics"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP_Latest(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		Name         string
+		Expected     statistics.Statistics
+		Error        error
+		ExpectsError bool
+		ExpectedCode int
+	}{
+		{
+			Name: "It should return the latest statistics",
+			Expected: statistics.Statistics{
+				Speed:             10,
+				Fuel:              11,
+				EngineTemperature: 12,
+				Revolutions:       13,
+			},
+			ExpectedCode: http.StatusOK,
+		},
+		{
+			Name:         "It should return return errors from the repository",
+			Error:        io.EOF,
+			ExpectsError: true,
+			ExpectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			repo := &MockRepository{stats: tc.Expected, err: tc.Error}
+			api := statistics.NewHTTP(repo)
+
+			router := mux.NewRouter()
+			api.Register(router)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/statistics/latest", nil)
+
+			router.ServeHTTP(w, r)
+			assert.EqualValues(t, tc.ExpectedCode, w.Code)
+			if tc.ExpectsError {
+				return
+			}
+
+			var actual statistics.Statistics
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&actual))
+			assert.EqualValues(t, tc.Expected, actual)
+		})
+	}
+}

--- a/internal/statistics/mocks_test.go
+++ b/internal/statistics/mocks_test.go
@@ -1,0 +1,18 @@
+package statistics_test
+
+import (
+	"context"
+
+	"github.com/cloud-lada/backend/internal/statistics"
+)
+
+type (
+	MockRepository struct {
+		stats statistics.Statistics
+		err   error
+	}
+)
+
+func (m *MockRepository) Latest(ctx context.Context) (statistics.Statistics, error) {
+	return m.stats, m.err
+}

--- a/internal/statistics/postgres.go
+++ b/internal/statistics/postgres.go
@@ -1,0 +1,74 @@
+package statistics
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/cloud-lada/backend/pkg/postgres"
+)
+
+type (
+	// The PostgresRepository is a Repository implementation that queries statistical data from a postgres-compatible
+	// database.
+	PostgresRepository struct {
+		db *sql.DB
+	}
+)
+
+// NewPostgresRepository returns a new instance of the PostgresRepository type that will perform queries against
+// the provided sql.DB instance.
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// Latest returns a Statistics type whose fields will be populated with the most recent data available within
+// the database.
+func (r *PostgresRepository) Latest(ctx context.Context) (Statistics, error) {
+	var stats Statistics
+	var err error
+
+	err = postgres.WithinTransaction(ctx, r.db, func(ctx context.Context, tx *sql.Tx) error {
+		stats.Speed, err = r.latestReading(ctx, tx, "speed")
+		if err != nil {
+			return err
+		}
+
+		stats.Fuel, err = r.latestReading(ctx, tx, "fuel")
+		if err != nil {
+			return err
+		}
+
+		stats.EngineTemperature, err = r.latestReading(ctx, tx, "engine_temperature")
+		if err != nil {
+			return err
+		}
+
+		stats.Revolutions, err = r.latestReading(ctx, tx, "revolution")
+		return err
+	})
+
+	return stats, err
+}
+
+func (r *PostgresRepository) latestReading(ctx context.Context, tx *sql.Tx, sensor string) (float64, error) {
+	const q = `
+		SELECT value FROM reading
+		WHERE sensor = $1
+		ORDER BY timestamp DESC 
+		FETCH FIRST ROW ONLY
+	`
+
+	var value float64
+	row := tx.QueryRowContext(ctx, q, sensor)
+
+	err := row.Scan(&value)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return value, nil
+	}
+}

--- a/internal/statistics/postgres_test.go
+++ b/internal/statistics/postgres_test.go
@@ -1,0 +1,66 @@
+package statistics_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloud-lada/backend/internal/reading"
+	"github.com/cloud-lada/backend/internal/statistics"
+	"github.com/cloud-lada/backend/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresRepository_Latest(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
+	ctx := testutil.Context(t)
+	db := testutil.Postgres(t, ctx)
+
+	readings := reading.NewPostgresRepository(db)
+	stats := statistics.NewPostgresRepository(db)
+
+	// Insert readings that we can query
+	seed := []reading.Reading{
+		{
+			Sensor:    "speed",
+			Value:     10,
+			Timestamp: time.Now(),
+		},
+		{
+			Sensor:    "fuel",
+			Value:     50,
+			Timestamp: time.Now(),
+		},
+		{
+			Sensor:    "engine_temperature",
+			Value:     30,
+			Timestamp: time.Now(),
+		},
+		{
+			Sensor:    "revolution",
+			Value:     1000,
+			Timestamp: time.Now(),
+		},
+	}
+
+	for _, s := range seed {
+		require.NoError(t, readings.Save(ctx, s))
+	}
+
+	t.Run("It should return the latest statistics", func(t *testing.T) {
+		expected := statistics.Statistics{
+			Speed:             10,
+			Fuel:              50,
+			EngineTemperature: 30,
+			Revolutions:       1000,
+		}
+
+		actual, err := stats.Latest(ctx)
+		require.NoError(t, err)
+		assert.EqualValues(t, expected, actual)
+	})
+}

--- a/internal/statistics/statistics.go
+++ b/internal/statistics/statistics.go
@@ -1,0 +1,13 @@
+// Package statistics provides all components required to serve statistical data via an HTTP API. It includes
+// the transport & persistence layers.
+package statistics
+
+type (
+	// The Statistics type contains fields describing the current state of the Lada.
+	Statistics struct {
+		Speed             float64 `json:"speed"`
+		Fuel              float64 `json:"fuel"`
+		EngineTemperature float64 `json:"engineTemperature"`
+		Revolutions       float64 `json:"revolutions"`
+	}
+)


### PR DESCRIPTION
This commit contains the initial source code for the API that the frontend
will use to display the current stats of the lada on its trip. It currently
has a single endpoint that returns the most recent reading data for speed,
engine temperature, fuel level and rpm.

Signed-off-by: David Bond <davidsbond93@gmail.com>