### PR TITLE
Change deployments to use entrypoint 

### DIFF
--- a/manifests/api/deployment.yaml
+++ b/manifests/api/deployment.yaml
@@ -19,8 +19,6 @@ spec:
       containers:
         - image: ghcr.io/cloud-lada/api:latest
           imagePullPolicy: IfNotPresent
-          command:
-            - /usr/bin/api
           args:
             - --database-url=$(DATABASE_URL)
             - --port=$(PORT)

--- a/manifests/dumper/cronjob.yaml
+++ b/manifests/dumper/cronjob.yaml
@@ -12,8 +12,6 @@ spec:
           containers:
             - image: ghcr.io/cloud-lada/dumper:latest
               imagePullPolicy: IfNotPresent
-              command:
-                - /usr/bin/dumper
               args:
                 - --database-url=$(DATABASE_URL)
                 - --blob-store-url=$(BLOB_STORE_URL)

--- a/manifests/ingestor/deployment.yaml
+++ b/manifests/ingestor/deployment.yaml
@@ -19,8 +19,6 @@ spec:
       containers:
         - image: ghcr.io/cloud-lada/ingestor:latest
           imagePullPolicy: IfNotPresent
-          command:
-            - /usr/bin/ingestor
           args:
             - --event-writer-url=$(EVENT_WRITER_URL)
             - --api-key=$(API_KEY)

--- a/manifests/persistor/deployment.yaml
+++ b/manifests/persistor/deployment.yaml
@@ -19,8 +19,6 @@ spec:
       containers:
         - image: ghcr.io/cloud-lada/persistor:latest
           imagePullPolicy: IfNotPresent
-          command:
-            - /usr/bin/persistor
           args:
             - --event-reader-url=$(EVENT_READER_URL)
             - --database-url=$(DATABASE_URL)


### PR DESCRIPTION
To make the dockerfile work dynamically, we had to set each application
to have their binary stored at /usr/bin/app. The deployments weren't
changed to reflect this.

Signed-off-by: David Bond <davidsbond93@gmail.com>