### PR TITLE
Add API endpoints for querying location

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The api accepts a small number of command-line flags to modify its behaviour:
 
 #### Endpoints
 
-* `/api/statistics/latest` (GET) - Returns the latest sensor data
+* `/api/statistics/latest` (GET) - Returns the latest sensor data.
+* `/api/location/latest` (GET) - Returns the latest location data.
 
 ## CI
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/cloud-lada/backend/internal/location"
 	"github.com/cloud-lada/backend/internal/statistics"
 	"github.com/cloud-lada/backend/pkg/postgres"
 	"github.com/gorilla/mux"
@@ -38,9 +39,10 @@ func main() {
 
 			logger := log.Default()
 			router := mux.NewRouter()
+			api := router.PathPrefix("/api").Subrouter()
 
-			api := statistics.NewHTTP(statistics.NewPostgresRepository(db))
-			api.Register(router)
+			statistics.NewHTTP(statistics.NewPostgresRepository(db)).Register(api)
+			location.NewHTTP(location.NewPostgresRepository(db)).Register(api)
 
 			svr := &http.Server{
 				Addr:    fmt.Sprint(":", port),

--- a/internal/location/http.go
+++ b/internal/location/http.go
@@ -1,0 +1,48 @@
+package location
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type (
+	// The HTTP type contains HTTP request handlers that serve location data.
+	HTTP struct {
+		location Repository
+	}
+
+	// The Repository interface describes types that can query location database from persistent
+	// storage.
+	Repository interface {
+		Latest(ctx context.Context) (Location, error)
+	}
+)
+
+// NewHTTP returns a new instance of the HTTP type that will serve location data queried from the
+// Repository implementation.
+func NewHTTP(location Repository) *HTTP {
+	return &HTTP{location: location}
+}
+
+// Latest handles an inbound HTTP GET request that returns the latest location stored within the Repository.
+func (h *HTTP) Latest(w http.ResponseWriter, r *http.Request) {
+	stats, err := h.location.Latest(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err = json.NewEncoder(w).Encode(stats); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// Register the HTTP routes into the given router.
+func (h *HTTP) Register(router *mux.Router) {
+	router.HandleFunc("/location/latest", h.Latest).Methods(http.MethodGet)
+}

--- a/internal/location/http_test.go
+++ b/internal/location/http_test.go
@@ -1,4 +1,4 @@
-package statistics_test
+package location_test
 
 import (
 	"encoding/json"
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cloud-lada/backend/internal/statistics"
+	"github.com/cloud-lada/backend/internal/location"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,18 +18,16 @@ func TestHTTP_Latest(t *testing.T) {
 
 	tt := []struct {
 		Name         string
-		Expected     statistics.Statistics
+		Expected     location.Location
 		Error        error
 		ExpectsError bool
 		ExpectedCode int
 	}{
 		{
-			Name: "It should return the latest statistics",
-			Expected: statistics.Statistics{
-				Speed:             10,
-				Fuel:              11,
-				EngineTemperature: 12,
-				Revolutions:       13,
+			Name: "It should return the latest location",
+			Expected: location.Location{
+				Longitude: 50,
+				Latitude:  51,
 			},
 			ExpectedCode: http.StatusOK,
 		},
@@ -43,14 +41,14 @@ func TestHTTP_Latest(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			repo := &MockRepository{stats: tc.Expected, err: tc.Error}
-			api := statistics.NewHTTP(repo)
+			repo := &MockRepository{location: tc.Expected, err: tc.Error}
+			api := location.NewHTTP(repo)
 
 			router := mux.NewRouter()
 			api.Register(router)
 
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest(http.MethodGet, "/statistics/latest", nil)
+			r := httptest.NewRequest(http.MethodGet, "/location/latest", nil)
 
 			router.ServeHTTP(w, r)
 			assert.EqualValues(t, tc.ExpectedCode, w.Code)
@@ -58,7 +56,7 @@ func TestHTTP_Latest(t *testing.T) {
 				return
 			}
 
-			var actual statistics.Statistics
+			var actual location.Location
 			require.NoError(t, json.NewDecoder(w.Body).Decode(&actual))
 			assert.EqualValues(t, tc.Expected, actual)
 		})

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -1,0 +1,10 @@
+// Package location provides the full application stack for location data. Including transport & querying.
+package location
+
+type (
+	// The Location type describes a point on the globe as a latitude and longitude.
+	Location struct {
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	}
+)

--- a/internal/location/mocks_test.go
+++ b/internal/location/mocks_test.go
@@ -1,0 +1,18 @@
+package location_test
+
+import (
+	"context"
+
+	"github.com/cloud-lada/backend/internal/location"
+)
+
+type (
+	MockRepository struct {
+		location location.Location
+		err      error
+	}
+)
+
+func (m *MockRepository) Latest(ctx context.Context) (location.Location, error) {
+	return m.location, m.err
+}

--- a/internal/location/postgres.go
+++ b/internal/location/postgres.go
@@ -1,0 +1,83 @@
+package location
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/cloud-lada/backend/pkg/postgres"
+)
+
+type (
+	PostgresRepository struct {
+		db *sql.DB
+	}
+)
+
+// NewPostgresRepository returns a new instance of the PostgresRepository type that will perform queries against
+// the provided sql.DB instance.
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// Latest returns the most recent location data stored within the database.
+func (r *PostgresRepository) Latest(ctx context.Context) (Location, error) {
+	var location Location
+	var err error
+
+	err = postgres.WithinReadOnlyTransaction(ctx, r.db, func(ctx context.Context, tx *sql.Tx) error {
+		location.Latitude, err = r.latestLatitude(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		location.Longitude, err = r.latestLongitude(ctx, tx)
+		return err
+	})
+
+	return location, err
+}
+
+func (r *PostgresRepository) latestLatitude(ctx context.Context, tx *sql.Tx) (float64, error) {
+	const q = `
+		SELECT value FROM reading
+		WHERE sensor = 'location_latitude'
+		ORDER BY timestamp DESC
+		FETCH FIRST ROW ONLY
+	`
+
+	var value float64
+	row := tx.QueryRowContext(ctx, q)
+
+	err := row.Scan(&value)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return value, nil
+	}
+}
+
+func (r *PostgresRepository) latestLongitude(ctx context.Context, tx *sql.Tx) (float64, error) {
+	const q = `
+		SELECT value FROM reading
+		WHERE sensor = 'location_longitude'
+		ORDER BY timestamp DESC
+		FETCH FIRST ROW ONLY
+	`
+
+	var value float64
+	row := tx.QueryRowContext(ctx, q)
+
+	err := row.Scan(&value)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return value, nil
+	}
+}

--- a/internal/location/postgres_test.go
+++ b/internal/location/postgres_test.go
@@ -1,0 +1,54 @@
+package location_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloud-lada/backend/internal/location"
+	"github.com/cloud-lada/backend/internal/reading"
+	"github.com/cloud-lada/backend/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresRepository_Latest(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
+	ctx := testutil.Context(t)
+	db := testutil.Postgres(t, ctx)
+
+	readings := reading.NewPostgresRepository(db)
+	locations := location.NewPostgresRepository(db)
+
+	// Insert readings that we can query
+	seed := []reading.Reading{
+		{
+			Sensor:    "location_latitude",
+			Value:     50,
+			Timestamp: time.Now(),
+		},
+		{
+			Sensor:    "location_longitude",
+			Value:     51,
+			Timestamp: time.Now(),
+		},
+	}
+
+	for _, s := range seed {
+		require.NoError(t, readings.Save(ctx, s))
+	}
+
+	t.Run("It should return the latest location", func(t *testing.T) {
+		expected := location.Location{
+			Longitude: 51,
+			Latitude:  50,
+		}
+
+		actual, err := locations.Latest(ctx)
+		require.NoError(t, err)
+		assert.EqualValues(t, expected, actual)
+	})
+}

--- a/internal/reading/postgres.go
+++ b/internal/reading/postgres.go
@@ -1,4 +1,3 @@
-// Package reading provides persistence logic for sensor readings.
 package reading
 
 import (
@@ -42,7 +41,7 @@ func (pr *PostgresRepository) Save(ctx context.Context, reading Reading) error {
 // each record, the ForEachFunc is invoked. Iteration will stop when there are no more records, the context is
 // cancelled or the ForEachFunc returns an error. Readings are processed in batches of 100 at the time.
 func (pr *PostgresRepository) ForEachOnDate(ctx context.Context, date time.Time, fn ForEachFunc) error {
-	return postgres.WithinTransaction(ctx, pr.db, func(ctx context.Context, tx *sql.Tx) error {
+	return postgres.WithinReadOnlyTransaction(ctx, pr.db, func(ctx context.Context, tx *sql.Tx) error {
 		const cursorQuery = `
 			DECLARE reading_cursor CURSOR FOR 
 			    SELECT sensor, value, timestamp FROM reading

--- a/internal/reading/reading.go
+++ b/internal/reading/reading.go
@@ -1,3 +1,5 @@
+// Package reading provides the full application stack for sensor readings. Including transport, persistence and
+// event handling.
 package reading
 
 import (

--- a/internal/statistics/http.go
+++ b/internal/statistics/http.go
@@ -44,5 +44,5 @@ func (h *HTTP) Latest(w http.ResponseWriter, r *http.Request) {
 
 // Register the HTTP routes into the given router.
 func (h *HTTP) Register(router *mux.Router) {
-	router.HandleFunc("/api/statistics/latest", h.Latest).Methods(http.MethodGet)
+	router.HandleFunc("/statistics/latest", h.Latest).Methods(http.MethodGet)
 }

--- a/internal/statistics/postgres.go
+++ b/internal/statistics/postgres.go
@@ -28,7 +28,7 @@ func (r *PostgresRepository) Latest(ctx context.Context) (Statistics, error) {
 	var stats Statistics
 	var err error
 
-	err = postgres.WithinTransaction(ctx, r.db, func(ctx context.Context, tx *sql.Tx) error {
+	err = postgres.WithinReadOnlyTransaction(ctx, r.db, func(ctx context.Context, tx *sql.Tx) error {
 		stats.Speed, err = r.latestReading(ctx, tx, "speed")
 		if err != nil {
 			return err


### PR DESCRIPTION
This commit adds the location endpoint to the API which serves the last
known lat/long value of the lada. It also includes seggregation of read/write
transactions.

Signed-off-by: David Bond <davidsbond93@gmail.com>