### PR TITLE
Remove requirement for sensor values to be positive

### DIFF
--- a/internal/reading/reading.go
+++ b/internal/reading/reading.go
@@ -21,8 +21,7 @@ func (r Reading) String() string {
 	return fmt.Sprint(r.Sensor, " ", r.Value, r.Timestamp)
 }
 
-// Valid returns true if the Reading is deemed to be in a valid state. This means a sensor name, a zero or
-// positive value and a non-zero timestamp.
+// Valid returns true if the Reading is deemed to be in a valid state. This means a sensor name and a non-zero timestamp.
 func (r Reading) Valid() bool {
-	return r.Sensor != "" && r.Value >= 0 && !r.Timestamp.IsZero()
+	return r.Sensor != "" && !r.Timestamp.IsZero()
 }


### PR DESCRIPTION
Since lat/long can be negative, this causes the ingestor to reject valid
lat/long combinations.

Signed-off-by: David Bond <davidsbond93@gmail.com>