### PR TITLE
Add API endpoint for serving data freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The api accepts a small number of command-line flags to modify its behaviour:
 
 * `/api/statistics/latest` (GET) - Returns the latest sensor data.
 * `/api/location/latest` (GET) - Returns the latest location data.
+* `/api/status` (GET) - Returns information on the freshness of reading data.
 
 ## CI
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cloud-lada/backend/internal/location"
 	"github.com/cloud-lada/backend/internal/statistics"
+	"github.com/cloud-lada/backend/internal/status"
 	"github.com/cloud-lada/backend/pkg/postgres"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -43,6 +44,7 @@ func main() {
 
 			statistics.NewHTTP(statistics.NewPostgresRepository(db)).Register(api)
 			location.NewHTTP(location.NewPostgresRepository(db)).Register(api)
+			status.NewHTTP(status.NewPostgresRepository(db)).Register(api)
 
 			svr := &http.Server{
 				Addr:    fmt.Sprint(":", port),

--- a/internal/status/http.go
+++ b/internal/status/http.go
@@ -1,0 +1,48 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type (
+	// The HTTP type contains HTTP request handlers that return the status of data ingestion.
+	HTTP struct {
+		statuses Repository
+	}
+
+	// The Repository interface describes types that can query the status of the data within the persistent
+	// storage.
+	Repository interface {
+		Status(ctx context.Context) (Status, error)
+	}
+)
+
+// NewHTTP returns a new instance of the HTTP type that will serve status data queried from the
+// Repository implementation.
+func NewHTTP(statuses Repository) *HTTP {
+	return &HTTP{statuses: statuses}
+}
+
+// Status handles an inbound HTTP GET request that returns information on the status of data ingestion from the
+// Repository.
+func (h *HTTP) Status(w http.ResponseWriter, r *http.Request) {
+	status, err := h.statuses.Status(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err = json.NewEncoder(w).Encode(status); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// Register the HTTP routes into the given router.
+func (h *HTTP) Register(router *mux.Router) {
+	router.HandleFunc("/status", h.Status).Methods(http.MethodGet)
+}

--- a/internal/status/http_test.go
+++ b/internal/status/http_test.go
@@ -1,0 +1,63 @@
+package status_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cloud-lada/backend/internal/status"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP_Status(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		Name         string
+		Expected     status.Status
+		ExpectedCode int
+		ExpectsError bool
+		Error        error
+	}{
+		{
+			Name: "It should return the current status",
+			Expected: status.Status{
+				LastIngestTimestamp: time.Now(),
+			},
+			ExpectedCode: http.StatusOK,
+		},
+		{
+			Name:         "It should propagate repository errors",
+			Error:        io.EOF,
+			ExpectsError: true,
+			ExpectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			repo := &MockRepository{status: tc.Expected, err: tc.Error}
+
+			router := mux.NewRouter()
+			status.NewHTTP(repo).Register(router)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/status", nil)
+
+			router.ServeHTTP(w, r)
+			assert.EqualValues(t, tc.ExpectedCode, w.Code)
+			if tc.ExpectsError {
+				return
+			}
+
+			var actual status.Status
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&actual))
+			assert.EqualValues(t, tc.Expected.LastIngestTimestamp.Unix(), actual.LastIngestTimestamp.Unix())
+		})
+	}
+}

--- a/internal/status/mocks_test.go
+++ b/internal/status/mocks_test.go
@@ -1,0 +1,18 @@
+package status_test
+
+import (
+	"context"
+
+	"github.com/cloud-lada/backend/internal/status"
+)
+
+type (
+	MockRepository struct {
+		status status.Status
+		err    error
+	}
+)
+
+func (m *MockRepository) Status(ctx context.Context) (status.Status, error) {
+	return m.status, m.err
+}

--- a/internal/status/postgres.go
+++ b/internal/status/postgres.go
@@ -1,0 +1,45 @@
+package status
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/cloud-lada/backend/pkg/postgres"
+)
+
+type (
+	// The PostgresRepository is a Repository implementation that queries status data from a postgres-compatible
+	// database.
+	PostgresRepository struct {
+		db *sql.DB
+	}
+)
+
+// NewPostgresRepository returns a new instance of the PostgresRepository type that will perform queries against
+// the provided sql.DB instance.
+func NewPostgresRepository(db *sql.DB) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+// Status returns the current status of data within the database.
+func (r *PostgresRepository) Status(ctx context.Context) (Status, error) {
+	var status Status
+
+	err := postgres.WithinReadOnlyTransaction(ctx, r.db, func(ctx context.Context, tx *sql.Tx) error {
+		const q = `SELECT MAX(timestamp) FROM reading`
+
+		row := tx.QueryRowContext(ctx, q)
+		err := row.Scan(&status.LastIngestTimestamp)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return nil
+		case err != nil:
+			return err
+		default:
+			return row.Err()
+		}
+	})
+
+	return status, err
+}

--- a/internal/status/postgres_test.go
+++ b/internal/status/postgres_test.go
@@ -1,0 +1,58 @@
+package status_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloud-lada/backend/internal/reading"
+	"github.com/cloud-lada/backend/internal/status"
+	"github.com/cloud-lada/backend/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresRepository_Status(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+		return
+	}
+
+	ctx := testutil.Context(t)
+	db := testutil.Postgres(t, ctx)
+
+	readings := reading.NewPostgresRepository(db)
+	statuses := status.NewPostgresRepository(db)
+
+	// Insert readings that we can query
+	seed := []reading.Reading{
+		{
+			Sensor:    reading.SensorTypeSpeed,
+			Value:     10,
+			Timestamp: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Sensor:    reading.SensorTypeSpeed,
+			Value:     10,
+			Timestamp: time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
+		},
+		{
+			Sensor:    reading.SensorTypeSpeed,
+			Value:     10,
+			Timestamp: time.Date(2021, 1, 1, 2, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, s := range seed {
+		require.NoError(t, readings.Save(ctx, s))
+	}
+
+	t.Run("It should return the latest status", func(t *testing.T) {
+		expected := status.Status{
+			LastIngestTimestamp: time.Date(2021, 1, 1, 2, 0, 0, 0, time.UTC),
+		}
+
+		actual, err := statuses.Status(ctx)
+		require.NoError(t, err)
+		assert.EqualValues(t, expected, actual)
+	})
+}

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,0 +1,12 @@
+// Package status provides all components required to serve data ingestion status via an HTTP API. It includes
+// the transport & persistence layers.
+package status
+
+import "time"
+
+type (
+	// The Status type contains fields describing the current status of the data within the backend.
+	Status struct {
+		LastIngestTimestamp time.Time `json:"lastIngestTimestamp"`
+	}
+)


### PR DESCRIPTION
This commit adds the `/api/status` endpoint that returns a JSON
response containing the last reading timestamp. This can be used
by the UI to determine how fresh the data is, and display a message
if data is out-of-date by a significant amount.

Signed-off-by: David Bond <davidsbond93@gmail.com>