### PR TITLE
Add API endpoint to power daily charts

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloud-lada/backend/internal/location"
 	"github.com/cloud-lada/backend/internal/statistics"
 	"github.com/cloud-lada/backend/internal/status"
+	"github.com/cloud-lada/backend/pkg/closers"
 	"github.com/cloud-lada/backend/pkg/postgres"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
@@ -37,6 +38,7 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("failed to connect to database: %w", err)
 			}
+			defer closers.Close(db)
 
 			logger := log.Default()
 			router := mux.NewRouter()

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/cloud-lada/backend/internal/reading"
+	"github.com/cloud-lada/backend/pkg/closers"
 	"github.com/cloud-lada/backend/pkg/event"
 	"github.com/cloud-lada/backend/pkg/middleware"
 	"github.com/gorilla/mux"
@@ -37,9 +38,9 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("failed to connect to event bus: %w", err)
 			}
+			defer closers.Close(writer)
 
 			logger := log.Default()
-
 			router := mux.NewRouter()
 			router.Use(middleware.APIKey(apiKey))
 
@@ -58,10 +59,6 @@ func main() {
 			grp.Go(func() error {
 				<-ctx.Done()
 				return svr.Shutdown(context.Background())
-			})
-			grp.Go(func() error {
-				<-ctx.Done()
-				return writer.Close()
 			})
 
 			logger.Println("Server started on port", port)

--- a/internal/dump/dump_test.go
+++ b/internal/dump/dump_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"log"
 	"testing"
 	"time"
 
@@ -65,7 +64,6 @@ func TestDumper_Dump(t *testing.T) {
 				Date:     tc.Date,
 				Readings: readings,
 				Blobs:    blobs,
-				Logger:   log.New(io.Discard, "", log.Flags()),
 			}
 
 			err := dump.New(config).Dump(ctx)

--- a/internal/location/postgres.go
+++ b/internal/location/postgres.go
@@ -9,6 +9,8 @@ import (
 )
 
 type (
+	// The PostgresRepository is a Repository implementation that queries location data from a postgres-compatible
+	// database.
 	PostgresRepository struct {
 		db *sql.DB
 	}

--- a/internal/reading/postgres_test.go
+++ b/internal/reading/postgres_test.go
@@ -23,7 +23,7 @@ func TestPostgresRepository_Save(t *testing.T) {
 
 	t.Run("It should store a reading", func(t *testing.T) {
 		assert.NoError(t, repo.Save(ctx, reading.Reading{
-			Sensor:    "test",
+			Sensor:    reading.SensorTypeSpeed,
 			Value:     100,
 			Timestamp: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		}))
@@ -31,7 +31,7 @@ func TestPostgresRepository_Save(t *testing.T) {
 
 	t.Run("It should not error for a duplicate reading", func(t *testing.T) {
 		assert.NoError(t, repo.Save(ctx, reading.Reading{
-			Sensor:    "test",
+			Sensor:    reading.SensorTypeSpeed,
 			Value:     100,
 			Timestamp: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
 		}))

--- a/internal/reading/reading.go
+++ b/internal/reading/reading.go
@@ -46,6 +46,11 @@ func (r Reading) String() string {
 // Valid returns true if the Reading is deemed to be in a valid state. This means a valid sensor type and a non-zero
 // timestamp.
 func (r Reading) Valid() bool {
-	_, ok := validSensorTypes[r.Sensor]
-	return ok && !r.Timestamp.IsZero()
+	return r.Sensor.Valid() && !r.Timestamp.IsZero()
+}
+
+// Valid returns true if the SensorType is one of the valid types of sensor.
+func (st SensorType) Valid() bool {
+	_, ok := validSensorTypes[st]
+	return ok
 }

--- a/internal/statistics/http_test.go
+++ b/internal/statistics/http_test.go
@@ -5,8 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
+	"time"
 
+	"github.com/cloud-lada/backend/internal/reading"
 	"github.com/cloud-lada/backend/internal/statistics"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +46,7 @@ func TestHTTP_Latest(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			repo := &MockRepository{stats: tc.Expected, err: tc.Error}
+			repo := &MockRepository{latest: tc.Expected, err: tc.Error}
 			api := statistics.NewHTTP(repo)
 
 			router := mux.NewRouter()
@@ -61,6 +64,74 @@ func TestHTTP_Latest(t *testing.T) {
 			var actual statistics.Statistics
 			require.NoError(t, json.NewDecoder(w.Body).Decode(&actual))
 			assert.EqualValues(t, tc.Expected, actual)
+		})
+	}
+}
+
+func TestHTTP_ForDate(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		Name         string
+		Expected     []statistics.Statistic
+		Date         time.Time
+		Sensor       reading.SensorType
+		Error        error
+		ExpectsError bool
+		ExpectedCode int
+	}{
+		{
+			Name:         "It should return statistics for the date",
+			Date:         time.Now(),
+			Sensor:       reading.SensorTypeSpeed,
+			ExpectedCode: http.StatusOK,
+			Expected: []statistics.Statistic{
+				{
+					Sensor:    reading.SensorTypeSpeed,
+					Value:     10,
+					Timestamp: time.Now(),
+				},
+			},
+		},
+		{
+			Name:         "It should return return errors from the repository",
+			Error:        io.EOF,
+			ExpectsError: true,
+			ExpectedCode: http.StatusInternalServerError,
+			Date:         time.Now(),
+			Sensor:       reading.SensorTypeSpeed,
+		},
+		{
+			Name:         "It should return bad request for an invalid sensor",
+			ExpectsError: true,
+			ExpectedCode: http.StatusBadRequest,
+			Date:         time.Now(),
+			Sensor:       "invalid",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.Name, func(t *testing.T) {
+			repo := &MockRepository{stats: tc.Expected, err: tc.Error}
+			api := statistics.NewHTTP(repo)
+
+			router := mux.NewRouter()
+			api.Register(router)
+
+			w := httptest.NewRecorder()
+
+			uri := path.Join("/statistics", "sensor", string(tc.Sensor), "date", tc.Date.Format("2006-02-01"))
+			r := httptest.NewRequest(http.MethodGet, uri, nil)
+
+			router.ServeHTTP(w, r)
+			assert.EqualValues(t, tc.ExpectedCode, w.Code)
+			if tc.ExpectsError {
+				return
+			}
+
+			var actuals []statistics.Statistic
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&actuals))
+			require.Len(t, actuals, len(tc.Expected))
 		})
 	}
 }

--- a/internal/statistics/mocks_test.go
+++ b/internal/statistics/mocks_test.go
@@ -2,17 +2,24 @@ package statistics_test
 
 import (
 	"context"
+	"time"
 
+	"github.com/cloud-lada/backend/internal/reading"
 	"github.com/cloud-lada/backend/internal/statistics"
 )
 
 type (
 	MockRepository struct {
-		stats statistics.Statistics
-		err   error
+		latest statistics.Statistics
+		stats  []statistics.Statistic
+		err    error
 	}
 )
 
-func (m *MockRepository) Latest(ctx context.Context) (statistics.Statistics, error) {
+func (m *MockRepository) ForDate(ctx context.Context, date time.Time, sensor reading.SensorType) ([]statistics.Statistic, error) {
 	return m.stats, m.err
+}
+
+func (m *MockRepository) Latest(ctx context.Context) (statistics.Statistics, error) {
+	return m.latest, m.err
 }

--- a/internal/statistics/statistics.go
+++ b/internal/statistics/statistics.go
@@ -2,6 +2,12 @@
 // the transport & persistence layers.
 package statistics
 
+import (
+	"time"
+
+	"github.com/cloud-lada/backend/internal/reading"
+)
+
 type (
 	// The Statistics type contains fields describing the current state of the Lada.
 	Statistics struct {
@@ -9,5 +15,12 @@ type (
 		Fuel              float64 `json:"fuel"`
 		EngineTemperature float64 `json:"engineTemperature"`
 		Revolutions       float64 `json:"revolutions"`
+	}
+
+	// The Statistic type contains fields describing a bucketed sensor value at a given time.
+	Statistic struct {
+		Sensor    reading.SensorType `json:"sensor"`
+		Value     float64            `json:"value"`
+		Timestamp time.Time          `json:"timestamp"`
 	}
 )

--- a/pkg/closers/closers.go
+++ b/pkg/closers/closers.go
@@ -1,0 +1,14 @@
+// Package closers provides utilities for working with io.Closer implementations.
+package closers
+
+import (
+	"io"
+	"log"
+)
+
+// Close the io.Closer. Logging the error if it is non-nil.
+func Close(c io.Closer) {
+	if err := c.Close(); err != nil {
+		log.Printf("failed to close %T: %v", c, err)
+	}
+}


### PR DESCRIPTION
This commit adds a new endpoint to the API that returns bucketed
reading data for a given date. This can be used to power the UI
charts that display daily data. The time buckets are fixed to 15
minute intervals, so there should be some decent visualisation we
can create from this.

It supports all sensor types and will validate the sensor type
on request.

Signed-off-by: David Bond <davidsbond93@gmail.com>