### PR TITLE
Use gapfilling

### DIFF
--- a/internal/statistics/postgres_test.go
+++ b/internal/statistics/postgres_test.go
@@ -96,7 +96,9 @@ func TestPostgresRepository_ForDate(t *testing.T) {
 
 		actual, err := stats.ForDate(ctx, date, reading.SensorTypeSpeed)
 		require.NoError(t, err)
-		require.Len(t, actual, 4)
+
+		// We expect 96 readings for 15 minute increments over 24 hours.
+		require.Len(t, actual, 96)
 
 		for _, elem := range actual {
 			assert.EqualValues(t, reading.SensorTypeSpeed, elem.Sensor)


### PR DESCRIPTION
This commit modifies the endpoint that returns the days worth of sensor
data to use timescaledb's gapfilling feature. This will make it
return every 15 minutes worth of data throughout the entire day using
the last known value if there is no reading.

Signed-off-by: David Bond <davidsbond93@gmail.com>