### PR TITLE
Bugfixes & improved gapfilling

### DIFF
--- a/internal/dump/dump_test.go
+++ b/internal/dump/dump_test.go
@@ -72,7 +72,7 @@ func TestDumper_Dump(t *testing.T) {
 				return
 			}
 
-			assert.EqualValues(t, tc.Date.Format("2006-02-01.json.gz"), blobs.name)
+			assert.EqualValues(t, tc.Date.Format("2006-01-02.json.gz"), blobs.name)
 
 			reader, err := gzip.NewReader(blobs.buffer)
 			require.NoError(t, err)

--- a/internal/statistics/http.go
+++ b/internal/statistics/http.go
@@ -56,7 +56,7 @@ func (h *HTTP) ForDate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	date, err := time.Parse("2006-02-01", vars["date"])
+	date, err := time.Parse("2006-01-02", vars["date"])
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -38,7 +38,7 @@ func (b *Bucket) Close() error {
 // NewWriter returns an io.WriteCloser implementation that will write binary data as a blob within the Bucket under
 // the specified name.
 func (b *Bucket) NewWriter(ctx context.Context, name string) (io.WriteCloser, error) {
-	writer, err := b.bucket.NewWriter(ctx, name, &blob.WriterOptions{})
+	writer, err := b.bucket.NewWriter(ctx, name, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -89,8 +89,8 @@ func withinTransaction(ctx context.Context, db *sql.DB, opts *sql.TxOptions, fn 
 	}
 
 	if err = fn(ctx, tx); err != nil {
-		if err = tx.Rollback(); err != nil {
-			return fmt.Errorf("failed to roll back transaction: %w", err)
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			return fmt.Errorf("failed to roll back transaction: %w", rollbackErr)
 		}
 
 		return err


### PR DESCRIPTION
This commit fixes a couple of bugs found while testing out gapfilling, and improves
the gapfilling implementation.

* Transaction rollbacks would set the actual error to nil, swallowing query errors.
* Gapfilling has been improved so all values that were carrying over are now set to zero.
* YYYY-MM-DD date formats were actually YYYY-DD-MM, this has been fixed.
* For some reason the dumper gets stuck, so I've made some changes to blob buckets and added calls to Flush to check what's going on.

Signed-off-by: David Bond <davidsbond93@gmail.com>