### PR TITLE
Set initial replicas to 1

### DIFF
--- a/manifests/api/deployment.yaml
+++ b/manifests/api/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: api
-  replicas: 3
+  replicas: 1
   strategy:
     type: RollingUpdate
   template:

--- a/manifests/ingestor/deployment.yaml
+++ b/manifests/ingestor/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: ingestor
-  replicas: 3
+  replicas: 1
   strategy:
     type: RollingUpdate
   template:

--- a/manifests/persistor/deployment.yaml
+++ b/manifests/persistor/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: persistor
-  replicas: 3
+  replicas: 1
   strategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
This commit modifies the deployment manifests to just have a single replica
per deployment instead of 3. For development (and likely production) a single
instance is all that is required.

Signed-off-by: David Bond <davidsbond93@gmail.com>